### PR TITLE
This PR Adds the ICARUS Run2 Trigger Database

### DIFF
--- a/triggerDatabase/FutureImprovements.md
+++ b/triggerDatabase/FutureImprovements.md
@@ -1,0 +1,17 @@
+Comment from Joseph Zennamo (Fermilab), 
+info from Justin Mueller 
+
+The read back from this database is a little 
+slow due to the fact that this database is 
+not indexed. If we want to index this database
+we can run this command:
+
+```
+sqlite3 <db>
+sqlite> CREATE INDEX i1 ON triggerdata(run_number);
+```
+
+the reason this wasn't done already is that it 
+increases the database file size above the 
+github file size limit (from ~85 MB to ~125 MB). 
+


### PR DESCRIPTION
This database contains all the information needed to classify ICARUS triggers as either majority (triggered) or Minimum Biased. 

This is related to this PR:
https://github.com/SBNSoftware/sbncode/pull/394
https://github.com/SBNSoftware/sbnobj/pull/100